### PR TITLE
Fix blank service editor when no form groups exist

### DIFF
--- a/src/pages/services/[id].js
+++ b/src/pages/services/[id].js
@@ -408,7 +408,7 @@ const ServiceEditor = props => {
             const formsByGroup = await api.forms()
             const forms = formsByGroup
                 .map(s => s.forms)
-                .reduce((acc, forms) => acc.concat(forms))
+                .reduce((acc, forms) => acc.concat(forms), [])
                 .sort((a, b) => (a.name > b.name ? 1 : -1))
             setForms(forms)
         }
@@ -712,7 +712,7 @@ const AddRequestDialog = ({
     handleClose,
     handleSubmit,
 }) => {
-    const availableForms = allForms.filter(
+    const availableForms = (allForms || []).filter(
         f => !forms.some(f2 => f2.id == f.id)
     )
     const [selected, setSelected] = useState()


### PR DESCRIPTION
## Problem

On sw-cacti, the staff service editor (`/services/<id>` → **Modify** tab) renders a blank white page. Confirmed live: the console throws two errors from `src/pages/services/[id].js`, then React errors #418/#423 unmount the pane:

1. `TypeError: Reduce of empty array with no initial value`
2. `TypeError: Cannot read properties of undefined (reading 'filter')`

## Root cause

`ServiceEditor` loads the form catalog with `api.forms()` (→ `GET /forms` → `api_formgroup.findAll()`) and flattens it:

```js
formsByGroup.map(s => s.forms).reduce((acc, forms) => acc.concat(forms))
```

The `reduce` has **no initial value**. Form groups are Django-era operational data that the migrations never seed (`00001` creates `api_formgroup`; nothing populates it), so on a fresh deploy `api.forms()` returns `[]`, the reduce throws, the `forms` state stays `undefined`, and `AddRequestDialog`'s `allForms.filter(...)` then crashes the render — blanking the whole Modify pane. QA/prod only survive because they happen to have form groups.

## Fix

- Give the `reduce` an initial value (`[]`) so an empty catalog flattens to `[]` instead of throwing.
- Default `allForms` to `[]` in `AddRequestDialog`.

The editor now renders regardless of whether any form groups exist (the "Add Request" picker is simply empty). This also removes a latent race where clicking **Modify** before the forms fetch resolves would crash on any environment.

## Verification

- Reproduced the exact two errors + blank page live on sw-cacti before the change.
- `prettier --check` passes on the modified file.
- No schema/data change; QA/prod behavior is unchanged (they already have form groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)