### PR TITLE
Seed the Resources form group (migration 00005)

### DIFF
--- a/migrations/00005_form_groups.down.sql
+++ b/migrations/00005_form_groups.down.sql
@@ -1,0 +1,5 @@
+-- 00005_form_groups.down.sql
+-- No-op: the form group seeded by the up migration is intentionally retained on rollback.
+-- Deleting these shared rows would strip the Resources group (and its form links) from
+-- environments that already have them. golang-migrate only requires this file to exist.
+SELECT 1;

--- a/migrations/00005_form_groups.up.sql
+++ b/migrations/00005_form_groups.up.sql
@@ -1,0 +1,25 @@
+-- 00005_form_groups.up.sql
+-- Seeds the "Resources" form group and its links to the two data-store request forms
+-- seeded by 00004 (form 2 = Data Store Shared Folder Request, form 7 = Community Released
+-- Data Folder). Form groups are Django-era data the migrations otherwise never seed; without
+-- at least one group the Requests page and the service editor's "Add Request" picker are
+-- empty. Only the in-scope group/links are carried over (the other QA form groups reference
+-- forms for features not deployed here). Guarded with ON CONFLICT DO NOTHING so it no-ops
+-- where the rows already exist (QA/prod) and populates fresh DBs.
+
+SET search_path = public, pg_catalog;
+
+BEGIN;
+
+-- api_formgroup (Resources)
+INSERT INTO public.api_formgroup (id, name, description, created_at, updated_at, index) VALUES ('2', 'Resources', 'Fill out these forms to expand the default resource limits for your account', '2017-03-30 12:01:28.796-07', '2017-03-30 13:05:56.201-07', '0') ON CONFLICT (id) DO NOTHING;
+
+-- api_formgroupform (Resources -> form 2, form 7)
+INSERT INTO public.api_formgroupform (id, created_at, updated_at, form_id, form_group_id) VALUES ('2', '2017-03-30 12:01:28.796-07', '2017-03-30 13:05:56.201-07', '2', '2') ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.api_formgroupform (id, created_at, updated_at, form_id, form_group_id) VALUES ('7', '2017-03-30 12:01:28.796-07', '2017-03-30 13:05:56.201-07', '7', '2') ON CONFLICT (id) DO NOTHING;
+
+-- Advance sequences past the seeded ids.
+SELECT pg_catalog.setval('public.api_formgroup_id_seq', (SELECT COALESCE(MAX(id), 1) FROM public.api_formgroup), true);
+SELECT pg_catalog.setval('public.api_formgroupform_id_seq', (SELECT COALESCE(MAX(id), 1) FROM public.api_formgroupform), true);
+
+COMMIT;


### PR DESCRIPTION
## Why

Form groups (`api_formgroup` / `api_formgroupform`) are Django-era operational data that the migrations never seed. On a fresh deploy `api.forms()` returns `[]`, so the **Requests** page is empty and the staff service editor's **Add Request** picker has nothing to offer. (That empty list is also what crashed the service editor before #8; this seeds real data so the feature is actually usable.)

## What

Seeds the **"Resources"** form group and its links to the two data-store request forms already seeded by `00004`:

- form 2 — Data Store Shared Folder Request
- form 7 — Community Released Data Folder

Only this in-scope group is carried over. QA's other three groups (Training / Teaching / Collaborate) link forms for features not deployed in the target environment (Atmosphere, webinars, Get Powered by CyVerse, external collaboration), so they're intentionally omitted.

Guarded with explicit ids + `ON CONFLICT DO NOTHING` so it no-ops where the rows already exist (QA/prod) and populates fresh DBs; the `api_formgroup` / `api_formgroupform` sequences are advanced afterward. Down migration is a no-op (shared rows retained on rollback), matching `00004`.

## Verification

Against a throwaway Postgres 16:
- `00001`→`00005` apply cleanly.
- The Resources group resolves to both forms; zero FK orphans.
- Re-applying `00005` is idempotent.
- `api.forms()` shape: one group with two forms (non-empty), so the flatten in the service editor and the Requests page both populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)