### PR TITLE
Add config toggle to make new-user email confirmation optional

### DIFF
--- a/portal2.template.json
+++ b/portal2.template.json
@@ -50,6 +50,7 @@
     "warningText": "Your profile needs attention"
   },
   "features": {
+    "disableRequireNewUserEmailConfirmation": false,
     "intercomEnabled": false
   },
   "sentry": {

--- a/src/api/lib/startup.js
+++ b/src/api/lib/startup.js
@@ -65,7 +65,9 @@ function validateStartupConfiguration() {
 
         // Test feature flags
         const features = config.getFeatures()
-        logger.info(`Feature flags: Intercom=${features.intercomEnabled}`)
+        logger.info(
+            `Feature flags: Intercom=${features.intercomEnabled} DisableRequireNewUserEmailConfirmation=${features.disableRequireNewUserEmailConfirmation}`
+        )
 
         // Test optional integrations
         const sentryConfig = config.getSentryConfig()

--- a/src/api/public.js
+++ b/src/api/public.js
@@ -2,9 +2,15 @@ const router = require('express').Router()
 const { logger } = require('./lib/logging')
 const {
     emailNewAccountConfirmation,
+    emailNewEmailConfirmation,
     emailPasswordReset,
 } = require('./lib/email')
-const { decodeHMAC, generateToken, decodeToken } = require('./lib/hmac')
+const {
+    decodeHMAC,
+    generateHMAC,
+    generateToken,
+    decodeToken,
+} = require('./lib/hmac')
 const { asyncHandler } = require('./lib/auth')
 const { encodePassword } = require('./lib/password')
 const config = require('./lib/config')
@@ -250,11 +256,29 @@ router.put(
                 logger.error('Error assigning email address to mailing list')
         } else logger.error('Mailing list not found: "announce"')
 
-        res.status(200).json(newUser)
-
-        // Send confirmation email (after the response as to not delay it)
         const hmac = generateToken(emailAddress.id)
-        await emailNewAccountConfirmation(newUser.email, hmac)
+        const skipEmailConfirmation =
+            config.getFeatures()?.disableRequireNewUserEmailConfirmation ===
+            true
+
+        // Respond first, then send the confirmation email so it doesn't delay
+        // the response
+        if (skipEmailConfirmation) {
+            // Return the set-password token so the UI can proceed without the
+            // email round-trip; still send a verify-this-address email so the
+            // user can confirm ownership later
+            res.status(200).json({
+                ...newUser.toJSON(),
+                password_token: hmac,
+            })
+            await emailNewEmailConfirmation(
+                newUser.email,
+                generateHMAC(emailAddress.id)
+            )
+        } else {
+            res.status(200).json(newUser)
+            await emailNewAccountConfirmation(newUser.email, hmac)
+        }
     })
 )
 
@@ -299,15 +323,20 @@ router.put(
 
         //TODO check that there is a password reset request for this HMAC
 
-        // Confirm email address
-        emailAddress.verified = true
-        emailAddress.primary = true
-        emailAddress.save()
-
         // Fetch user unscoped so password is present
         const user = await User.unscoped().findByPk(emailAddress.user_id, {
             include: ['occupation'],
         })
+
+        // Confirm email address. When email confirmation is disabled, new
+        // users reach this endpoint without an emailed link, so ownership is
+        // unproven -- leave unverified (they can confirm via /confirm_email).
+        const skipVerify =
+            config.getFeatures()?.disableRequireNewUserEmailConfirmation ===
+                true && user.password === ''
+        if (!skipVerify) emailAddress.verified = true
+        emailAddress.primary = true
+        emailAddress.save()
 
         // Log password set/reset
         const newPasswordReset = PasswordReset.create({

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -325,6 +325,7 @@ const ForgotPassword = ({ startTimeHMAC, cancelHandler }) => {
 const SignUp = ({ startTimeHMAC, firstNameId, lastNameId }) => {
     const { classes } = useStyles()
     const api = useAPI()
+    const router = useRouter()
     const [error, setError] = useState()
 
     const [institutions, setInstitutions] = useState([])
@@ -401,7 +402,10 @@ const SignUp = ({ startTimeHMAC, firstNameId, lastNameId }) => {
             const newUser = await api.createUser(submission)
             if (!newUser || typeof newUser != 'object')
                 setError('An error occurred')
-            else {
+            else if (newUser.password_token) {
+                // Email confirmation not required -- go straight to set-password
+                router.push(`/password?code=${newUser.password_token}`)
+            } else {
                 setUser(newUser)
                 setSubmitted(true)
             }


### PR DESCRIPTION
## Summary

Adds a feature flag `features.disableRequireNewUserEmailConfirmation` (default `false` / absent = current behavior). When enabled, new users can fully register and log in without confirming their email address first.

Today the confirmation requirement is implicit: signup creates a DB-only user with an empty password and emails a link to `/password?code=<token>`; only that page's `PUT /api/users/password` call stores the password, creates the LDAP/iRODS account via portal-conductor, and grants default services. This PR keeps that entire flow intact and, when the flag is on, simply skips the email round-trip.

## Changes

- **`portal2.template.json`** — new `features.disableRequireNewUserEmailConfirmation: false` key.
- **`src/api/public.js` (signup)** — when the flag is on, the `PUT /api/users` response includes a `password_token` field (the same 3-day set-password token normally delivered by email), and the outbound email switches to the verify-this-address style linking `/confirm_email` — the normal signup email's `/password` link would be rejected by the single-use replay check once the password is set inline.
- **`src/api/public.js` (password set)** — when the flag is on and the user is new (`password === ''`), the email's `verified` flag stays `false` since ownership was never proven; the user can verify later via the emailed `/confirm_email` link or the account page's "Resend Confirmation Email". Password resets still set `verified = true` (the reset link proves address control).
- **`src/pages/welcome.js`** — on signup success, if the response carries `password_token`, redirect straight to `/password?code=...` instead of showing the "check your email" screen.
- **`src/api/lib/startup.js`** — include the new flag in the startup feature-flags log line.

Frontend detection is response-shape driven (`password_token` present), so the flag lives only in the backend config — no `publicRuntimeConfig`/`next.config.js` plumbing and no frontend/backend config skew.

## Security considerations

- With the flag on, an unauthenticated `PUT /api/users` returns an account-activation token. The endpoint's existing bot defenses remain the gate: honeypot fields, page-load-time HMAC window, username/email uniqueness, and the restricted-username list.
- Accounts become fully provisioned (LDAP/iRODS + default services) without proof of email ownership — that is the feature's purpose. `verified=false` remains visible to admins as a signal.
- Email squatting: registering someone else's address already blocks the real owner today; with the flag on the squatter also gets a working account. Acknowledged trade-off of the feature.
- The token transits `/password?code=` in the URL — identical exposure to today's emailed link.

## Edge cases

- A user who signed up while the flag was **off** but clicks their emailed `/password` link while it's **on** ends up `verified=false` despite proving ownership; self-serviceable via the account page's resend link. Errs safe.
- A flag-on user who abandons the `/password` page before setting a password has no `/password` link in their inbox; recovery is the forgot-password flow, which already handles empty-password users (runs the user-creation workflow).
- The `add_email_confirmation` email template wording is reused as-is for signup; can be revisited if the copy matters.

## Test plan

No JS test suite exists in the repo; verified manually:

- [x] `node --check` on both backend files; prettier check on all touched JS; both JSON configs parse
- [x] Dev server starts, config validates, and logs `Feature flags: Intercom=false DisableRequireNewUserEmailConfirmation=false`
- [ ] Flag off: signup → "confirmation email sent" view, emailed `/password` link sets password, `verified=true`, workflow + default services run (unchanged behavior)
- [ ] Flag on: signup → immediate redirect to `/password`, inline password set → login works, default services granted, DB shows `verified=false`; emailed `/confirm_email` link (or account-page resend) sets `verified=true`
- [ ] Replay of a used `/password?code=` link still returns "Password already set/reset"

🤖 Generated with [Claude Code](https://claude.com/claude-code)