### PR TITLE
Fix unusable checkboxes on request form pages

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -59,8 +59,12 @@ const initialValues = fields =>
     }, {})
 
 const validateField = (field, value) => {
-    if ((field.is_required || field.required) && isEmpty(value))
-        return 'This field is required'
+    const required = field.is_required || field.required
+    // Checkboxes are only satisfied when actually checked; isEmpty() would
+    // accept an unchecked box because `false` is a non-empty value.
+    if (field.type == 'boolean' || field.type == 'toggle')
+        return required && value !== true ? 'This field is required' : null
+    if (required && isEmpty(value)) return 'This field is required'
     if (field.type == 'email' && !isEmail(value))
         return 'A valid email address is required'
     if (field.type == 'number' && (!isNumeric(value) || value <= 0))
@@ -88,7 +92,9 @@ const validateFields = async (fields, values, customValidator) => {
     let errors = {}
     for (let field of fields) {
         const id = field.id
-        const value = id in values ? '' + values[id] : '' // force to string type
+        const raw = id in values ? values[id] : ''
+        // force to string type, except booleans so checkbox state survives
+        const value = typeof raw === 'boolean' ? raw : '' + raw
 
         let error = validateField(field, value)
         if (!error && customValidator)

--- a/src/components/FormikCheckboxWithLabel.js
+++ b/src/components/FormikCheckboxWithLabel.js
@@ -1,26 +1,23 @@
 import React from 'react'
-import { Field } from 'formik'
 import { Checkbox, FormControlLabel } from '@mui/material'
 
-const FormikCheckboxWithLabel = ({ name, label, ...props }) => {
+// Drop-in replacement for formik-material-ui's CheckboxWithLabel. Used as the
+// `component` of a Formik <Field>, which supplies `field`/`form` as props and
+// consumes `name` itself, and passes the label as `Label={{ label, ...rest }}`.
+const FormikCheckboxWithLabel = ({
+    field,
+    form,
+    Label = {},
+    defaultValue,
+    ...props
+}) => {
+    const { label, ...labelProps } = Label
     return (
-        <Field name={name}>
-            {({ field, form }) => (
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            {...field}
-                            checked={field.value}
-                            onChange={e => {
-                                form.setFieldValue(name, e.target.checked)
-                            }}
-                            {...props}
-                        />
-                    }
-                    label={label}
-                />
-            )}
-        </Field>
+        <FormControlLabel
+            control={<Checkbox {...props} {...field} checked={!!field.value} />}
+            label={label}
+            {...labelProps}
+        />
     )
 }
 


### PR DESCRIPTION
Fixes the broken checkboxes reported on the Community Released Data Folder request page (`/requests/7`, last step), where two checkboxes rendered with no label, appeared permanently checked, and could not be toggled.

## Root cause

Commit 9d40f44 replaced `formik-material-ui`'s `CheckboxWithLabel` with a custom wrapper but left the call site in `Form.js` (the `type === 'boolean'` branch) on the old API. The two never agreed on props.

The mechanism behind the stuck state: Formik's `<Field component={C}>` **consumes `name` itself and does not forward it**. The wrapper's `name` was therefore `undefined`, and its inner `<Field name={undefined}>` made `getIn(values, undefined)` return the **entire values object** — always truthy — so `checked` was effectively hardcoded `true` regardless of the field's real value. Clicking changed state that the render ignored.

The missing label has the same origin: the call site passes `Label={{ label, className }}` while the wrapper read `label`. The unconsumed `field`/`form`/`Label` props then spread onto the DOM, producing the `field="[object Object]"` attributes visible in devtools.

## Changes

- **`src/components/FormikCheckboxWithLabel.js`** — made it a genuine drop-in for `CheckboxWithLabel`: consumes `field`/`form` from Formik, reads the label out of `Label`, binds `checked={!!field.value}`, and keeps leftover props off the input. The `Form.js` call site is unchanged.
- **`src/components/Form.js`** — a second defect became reachable once checkboxes worked: a **required** boolean passed validation while unchecked, because `validateFields` stringified `false` to `"false"` and `isEmpty()` treats that as filled. On this form that meant you could submit **without agreeing to the CyVerse Data Policy**. Booleans now stay unstringified, and required boolean/toggle fields require an actual `true`.

## Verification

- Table-driven harness against the real `validateFields`: 11 cases pass. Confirmed meaningful — pre-fix code fails exactly the 2 intended cases (required bool unchecked, required toggle off) and nothing else.
- Component harness rendering the real wrapper: correct for `''` / `true` / `false`, zero React warnings.
- Live against QA: labels render, boxes toggle independently, Submit stays disabled with zero or one box checked and enables only with both. Submit was **not** clicked, to avoid filing a real QA request.
- Regression check on the admin form editor (the other consumer of the boolean branch): labels and per-field checked states now correct.
- `npm run build` passes; prettier clean.

## Not addressed here

Text fields share the same prop-leak pattern (`name=""`, `field`/`form` on the wrapper div). They work by falling back to `id`, so it is cosmetic, and it is outside the scope of this report — worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)