### PR TITLE
Fix hydration mismatch from nested anchors in the sidebar

### DIFF
--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -40,28 +40,23 @@ const NavButton = props => {
 
     return (
         <div>
-            <Link href={props.path}>
-                <ListItemButton
-                    component="a"
-                    className={`${classes.listItem} ${
-                        isSelected ? classes.selected : ''
-                    }`}
+            <ListItemButton
+                component={Link}
+                href={props.path}
+                className={`${classes.listItem} ${
+                    isSelected ? classes.selected : ''
+                }`}
+            >
+                <ListItemIcon
+                    className={isSelected ? classes.selectedIcon : classes.icon}
                 >
-                    <ListItemIcon
-                        className={
-                            isSelected ? classes.selectedIcon : classes.icon
-                        }
-                    >
-                        {props.icon}
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={props.label}
-                        className={
-                            isSelected ? classes.selectedText : classes.text
-                        }
-                    />
-                </ListItemButton>
-            </Link>
+                    {props.icon}
+                </ListItemIcon>
+                <ListItemText
+                    primary={props.label}
+                    className={isSelected ? classes.selectedText : classes.text}
+                />
+            </ListItemButton>
         </div>
     )
 }


### PR DESCRIPTION
Fixes the React hydration errors seen on every page: **6x #418** ("Hydration failed because the initial UI does not match what was rendered on the server") followed by **1x #423** ("the entire root will switch to client rendering").

The #423 is the significant one — it means React threw away the server-rendered markup and re-rendered the whole page on the client, so SSR was being wasted on every request.

## Root cause

The sidebar nav buttons emitted **nested anchors**.

Under Next 12, `<Link passHref>` cloned its child and injected `href`, yielding one anchor. The new-link codemod in e548476 dropped `passHref`, and in Next 14 `<Link>` renders its own `<a>`. So each nav item served:

```html
<a href="/services"><a class="MuiListItemButton-root" role="button">…</a></a>
```

Nested `<a>` is invalid HTML. The parser applies the implied-end-tag rule and reparents the inner anchor into a **sibling**, so the browser built `<a></a><a>…</a>` while React's tree expected one anchor wrapping the other — a structural mismatch per nav item.

Verified directly against the served markup: each nav container held **two sibling anchors** on the server and **one** on the client.

## Change

Make Next's `Link` the root of the `ListItemButton` instead of nesting the two. That emits a single valid `<a href>` and keeps the MUI styling, ripple, and button semantics.

## Verification

A/B against a production build (`next build` + `next start`), console cleared between runs:

| Build | React errors per page load |
|---|---|
| before | 6x #418 + 1x #423 (reproduced on two consecutive loads) |
| after | **none** on `/requests`, `/services`, `/workshops` |

Also confirmed: nav renders with correct labels and styling, client-side routing works via nav clicks, and the selected-item highlight updates correctly.

Ruled out along the way: a ProtonPass browser extension injects one node, but it is appended to `<body>` **outside** `#__next`, so it does not affect hydration.

## Follow-ups (not in this PR)

Two separate issues surfaced while debugging; neither is touched here:

1. **`npm run dev` is unusable.** `express-ws` in `src/server.js` intercepts Next's HMR upgrade (`/_next/webpack-hmr/.websocket` -> 404 -> invalid close code), which wedges or kills the dev server on first page load. I worked around it with a production build.
2. **`Dashboard.js:158` null-derefs `user.settings`** when there is no authenticated user, so any unauthenticated render 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)