### PR TITLE
Match email addresses case-insensitively on password reset

### DIFF
--- a/src/api/mailing_lists.js
+++ b/src/api/mailing_lists.js
@@ -214,8 +214,10 @@ router.post(
         const userId = targetUserId || req.user.id
         const emailAddress = await EmailAddress.findOne({
             where: {
-                email: email,
-                user_id: userId,
+                [sequelize.Op.and]: [
+                    lowerEqualTo('email', email),
+                    { user_id: userId },
+                ],
             },
         })
         if (!emailAddress)

--- a/src/api/public.js
+++ b/src/api/public.js
@@ -418,14 +418,32 @@ router.post(
 
         if (!email) return res.status(400).send('Missing email')
 
-        let emailAddress = await EmailAddress.findOne({
-            where: { email },
+        // Signup lowercases before storing, but the column is a plain varchar
+        // with no normalizing hook and the data predates this app, so match
+        // case-insensitively on both sides. The column has to be qualified:
+        // include: ['user'] joins account_user, which also has an email column.
+        const matches = await EmailAddress.findAll({
+            where: lowerEqualTo('account_emailaddress.email', email),
             include: ['user'],
         })
-        if (!emailAddress)
+        if (!matches.length)
             return res
                 .status(404)
                 .send('Email address not associated with an account')
+
+        // The unique constraint is case-sensitive, so addresses differing only
+        // in case can belong to different users. Prefer the exact match rather
+        // than mailing a reset link for whichever row happened to come back.
+        let emailAddress = matches.find(match => match.email === email)
+        if (!emailAddress) {
+            if (matches.length > 1)
+                return res
+                    .status(409)
+                    .send(
+                        'Multiple accounts use that email address, please contact support'
+                    )
+            emailAddress = matches[0]
+        }
 
         // Detect bots using page load time
         if (!pltHMAC) return res.status(400).send('Missing HMAC')
@@ -449,7 +467,7 @@ router.post(
             user_id: emailAddress.user.id,
             username: emailAddress.user.username,
             email_address_id: emailAddress.id,
-            email: email,
+            email: emailAddress.email,
             key: hmac,
         })
         if (!passwordResetRequest)

--- a/src/api/workflows/native/services/utils.js
+++ b/src/api/workflows/native/services/utils.js
@@ -188,7 +188,10 @@ async function makeRequest(method, endpoint, data = null, options = {}) {
                 }): ${method} ${requestConfig.url}`
             )
             if (data) {
-                logger.debug(`Portal-conductor request data:`, data)
+                logger.debug(
+                    `Portal-conductor request data:`,
+                    JSON.stringify(data, null, 2)
+                )
             }
             const response = await axios(requestConfig)
             logger.debug(`Portal-conductor response: ${response.status}`)

--- a/src/api/workflows/native/services/utils.js
+++ b/src/api/workflows/native/services/utils.js
@@ -192,7 +192,7 @@ async function makeRequest(method, endpoint, data = null, options = {}) {
                     `Portal-conductor request data:`,
                     JSON.stringify(
                         data,
-                        () => {
+                        (key, value) => {
                             return key.toLowerCase().includes('password')
                                 ? '********'
                                 : value

--- a/src/api/workflows/native/services/utils.js
+++ b/src/api/workflows/native/services/utils.js
@@ -190,7 +190,15 @@ async function makeRequest(method, endpoint, data = null, options = {}) {
             if (data) {
                 logger.debug(
                     `Portal-conductor request data:`,
-                    JSON.stringify(data, null, 2)
+                    JSON.stringify(
+                        data,
+                        () => {
+                            return key.toLowerCase().includes('password')
+                                ? '********'
+                                : value
+                        },
+                        2
+                    )
                 )
             }
             const response = await axios(requestConfig)


### PR DESCRIPTION
The reset handler looked the address up with a plain `where: { email }` against a varchar column, so a user who typed JARinger@salud.unm.edu was told the address was not associated with an account while the all-lower form worked. The client-side check on the same form already goes through lowerEqualTo, which is why the mismatch only surfaced on submit.

Signup lowercases before storing, but nothing enforces that at the model level and the data predates this app, so the comparison has to lower both sides rather than just the input.

Two details the straightforward swap gets wrong:

  - The column must be qualified. `include: ['user']` joins account_user, which also has an email column, and an unqualified `email` inside that join raises "column reference is ambiguous".

  - The unique constraint on account_emailaddress.email is case-sensitive, so two users can hold addresses differing only in case. A case-insensitive findOne would pick one arbitrarily and could mail a reset link for the wrong account. Collect the matches, prefer an exact match, and refuse with a 409 when it is still ambiguous.

Record the stored address on the reset request rather than the raw input, and apply the same case-insensitive match to the mailing-list subscribe lookup, which failed the same way.