### PR TITLE
Fix the DE - VICE service page 404ing on a doubled slash

### DIFF
--- a/src/constants/server.js
+++ b/src/constants/server.js
@@ -1,6 +1,7 @@
 // Server-side constants that use configuration
 // NOTE: this module can only be used server-side due to use of configuration manager
 const config = require('../api/lib/config')
+const { joinUrl } = require('../api/lib/url')
 
 const uiConfig = config.getUiConfig()
 const terrainConfig = config.getTerrainConfig()
@@ -17,6 +18,12 @@ module.exports = {
     UI_ACCOUNT_REVIEW_URL: `${uiConfig.baseUrl}/account?reviewMode=1`,
 
     // External URLs
-    EXT_ADMIN_VICE_ACCESS_REQUEST_API_URL: `${terrainConfig.url}/admin/settings/concurrent-job-limits`,
+    // joinUrl, not interpolation: terrain.url is commonly configured with a
+    // trailing slash, and terrain answers a doubled slash with Jetty's HTML
+    // error page rather than JSON.
+    EXT_ADMIN_VICE_ACCESS_REQUEST_API_URL: joinUrl(
+        terrainConfig.url,
+        'admin/settings/concurrent-job-limits'
+    ),
     EXT_ADMIN_VICE_ACCESS_REQUEST_URL: 'https://de.cyverse.org/admin/vice',
 }

--- a/src/pages/services/[id].js
+++ b/src/pages/services/[id].js
@@ -765,6 +765,7 @@ export async function getServerSideProps({ req, query }) {
             EXT_ADMIN_VICE_ACCESS_REQUEST_API_URL,
         } = require('../../constants/server')
         const config = require('../../api/lib/config')
+        const { joinUrl } = require('../../api/lib/url')
 
         if (!req.api) {
             throw new Error('API not available on request object')
@@ -779,33 +780,60 @@ export async function getServerSideProps({ req, query }) {
 
         let viceStatus = null
 
-        // Special case: fetch VICE access request status
+        // Special case: fetch VICE access request status. This only decides how
+        // the access-request control renders, so a failure here degrades to an
+        // unknown status rather than taking the whole page down with a 404.
         if (service.name == 'DE - VICE') {
-            const user = await req.api.user()
-            const terrainConfig = config.getTerrainConfig()
+            try {
+                const user = await req.api.user()
+                const terrainConfig = config.getTerrainConfig()
 
-            // Get Terrain token
-            let resp = await fetch(`${terrainConfig.url}/token/keycloak`, {
-                headers: {
-                    Authorization:
-                        'Basic ' +
-                        Buffer.from(
-                            terrainConfig.user + ':' + terrainConfig.password
-                        ).toString('base64'),
-                },
-            })
-            let data = await resp.json()
+                // Get Terrain token
+                let resp = await fetch(
+                    joinUrl(terrainConfig.url, 'token/keycloak'),
+                    {
+                        headers: {
+                            Authorization:
+                                'Basic ' +
+                                Buffer.from(
+                                    terrainConfig.user +
+                                        ':' +
+                                        terrainConfig.password
+                                ).toString('base64'),
+                        },
+                    }
+                )
+                if (!resp.ok)
+                    throw new Error(
+                        `terrain token request failed: ${resp.status}`
+                    )
+                let data = await resp.json()
 
-            // Get concurrent jobs setting
-            resp = await fetch(
-                `${EXT_ADMIN_VICE_ACCESS_REQUEST_API_URL}/${user.username}`,
-                {
-                    headers: { Authorization: `Bearer ${data.access_token}` },
-                }
-            )
-            data = await resp.json()
-            viceStatus =
-                data && data.concurrent_jobs && data.concurrent_jobs > 0
+                // Get concurrent jobs setting
+                resp = await fetch(
+                    joinUrl(
+                        EXT_ADMIN_VICE_ACCESS_REQUEST_API_URL,
+                        user.username
+                    ),
+                    {
+                        headers: {
+                            Authorization: `Bearer ${data.access_token}`,
+                        },
+                    }
+                )
+                if (!resp.ok)
+                    throw new Error(
+                        `terrain concurrent-job-limits request failed: ${resp.status}`
+                    )
+                data = await resp.json()
+                viceStatus =
+                    data && data.concurrent_jobs && data.concurrent_jobs > 0
+            } catch (error) {
+                console.error(
+                    'Could not determine VICE access status; the service page will render without it:',
+                    error
+                )
+            }
         }
 
         return { props: { service, viceStatus } }


### PR DESCRIPTION
The service detail page built its two terrain URLs by interpolation: `${terrainConfig.url}/token/keycloak`. terrain.url is normally configured with a trailing slash (the deployments role default is `https://{{ de_hostname }}/terrain/`, and sw-cacti uses `http://terrain/`), so the request went to `http://terrain//token/keycloak`. Verified from inside the pod:

  http://terrain/token/keycloak   => 401, empty body
  http://terrain//token/keycloak  => 400, "<html>\n<head>\n<meta ..."

resp.json() then threw on the HTML, and because getServerSideProps wraps everything in a try that returns notFound, the whole page rendered as a
404. Nothing else on the page is affected, which is why only DE - VICE -- the one service with this special case -- was broken.

Use joinUrl, which exists for exactly this ("ensuring no double slashes", "may or may not have trailing slash") and which the VICE request workflow already uses.

Also stop letting this probe fail the page. It only decides how the access-request control renders, so wrap it and degrade to an unknown status, and check resp.ok so a bad response is logged as a status rather than as a JSON parse error further down.